### PR TITLE
Rebase T-head glibc 2.36

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -138,6 +138,18 @@
 /* LOONGARCH floating-point ABI for ld.so.  */
 #undef LOONGARCH_ABI_FRLEN
 
+/* RISC-V xthead ARCH for ld.so.  */
+#undef RISCV_ARCH_XTHEAD
+
+/* RISC-V vector length ABI for ld.so.  */
+#undef RISCV_ABI_VLEN
+
+/* RISC-V vector ABI for ld.so.  */
+#undef RISCV_ABI_VECTOR
+
+/* RISC-V v-ext version for ld.so.  */
+#undef RISCV_ARCH_V
+
 /* Linux specific: minimum supported kernel version.  */
 #undef	__LINUX_KERNEL_VERSION
 

--- a/sysdeps/riscv/preconfigure
+++ b/sysdeps/riscv/preconfigure
@@ -7,6 +7,10 @@ riscv*)
     flen=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_flen \(.*\)/\1/p'`
     float_abi=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_float_abi_\([^ ]*\) .*/\1/p'`
     atomic=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | grep '#define __riscv_atomic' | cut -d' ' -f2`
+    arch_xthead=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_xtheadc.*/yes/p'`
+    vlen=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_vector \(.*\)/\1/p'`
+    arch_v=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_v \(.*\)/\1/p'`
+    vector_abi=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_vector_abi_\([^ ]*\) .*/\1/p'`
 
     case "$xlen" in
     64 | 32)
@@ -55,6 +59,42 @@ riscv*)
 	;;
     esac
 
+    case "$arch_xthead" in
+    yes*)
+        is_arch_xthead=1
+        ;;
+    *)
+        is_arch_xthead=0
+        ;;
+    esac
+
+    case "$vlen" in
+    "")
+        abi_vlen=0
+        ;;
+    *)
+        abi_vlen=$vlen
+        ;;
+    esac
+
+    case "$vector_abi" in
+    v)
+        vector_abi=1
+        ;;
+    *)
+        vector_abi=0
+        ;;
+    esac
+
+    case "$arch_v" in
+    "")
+        arch_v=0
+        ;;
+    *)
+        arch_v=$arch_v
+        ;;
+    esac
+
     base_machine=riscv
     machine=riscv/rv$xlen/$float_machine
 
@@ -66,5 +106,11 @@ _ACEOF
 #define RISCV_ABI_FLEN $abi_flen
 _ACEOF
 
+    $as_echo "#define RISCV_ABI_XLEN $xlen" >>confdefs.h
+    $as_echo "#define RISCV_ABI_FLEN $abi_flen" >>confdefs.h
+    $as_echo "#define RISCV_ARCH_XTHEAD $is_arch_xthead" >>confdefs.h
+    $as_echo "#define RISCV_ABI_VLEN $abi_vlen" >>confdefs.h
+    $as_echo "#define RISCV_ARCH_V $arch_v" >>confdefs.h
+    $as_echo "#define RISCV_ABI_VECTOR $vector_abi" >>confdefs.h
     ;;
 esac

--- a/sysdeps/riscv/rv64/memcpy.S
+++ b/sysdeps/riscv/rv64/memcpy.S
@@ -1,0 +1,159 @@
+/* The assembly function for memcpy.  RISC-V version.
+   Copyright (C) 2018 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <sysdep.h>
+
+#  define LABLE_ALIGN   \
+        .balignl 16, 0x00000013
+
+#if defined(__riscv_v) && (__riscv_v >= 1000000)
+# define VLDB vle8.v
+# define VSTB vse8.v
+#else
+# define VLDB vlb.v
+# define VSTB vsb.v
+#endif
+
+ENTRY (memcpy)
+#if defined(__riscv_vector)
+	mv	a3, a0
+	sltiu	a4, a2, 16
+	bnez	a4, .loop_cpy
+	andi	a5, a0, 15
+	li	a6, 16
+	beqz	a5, .loop_cpy
+	sub	a5, a6, a5
+	vsetvli	t0, a5, e8, m4
+	VLDB	v0, (a1)
+	add	a1, a1, t0
+	sub	a2, a2, t0
+	VSTB	v0, (a3)
+	add	a3, a3, t0
+.loop_cpy:
+	vsetvli	t0, a2, e8, m4
+	VLDB	v0, (a1)
+	add	a1, a1, t0
+	sub	a2, a2, t0
+	VSTB	v0, (a3)
+	add	a3, a3, t0
+	bnez	a2, .loop_cpy
+	ret
+#else
+        /* Test if len less than 8 bytes.  */
+        mv      t6, a0
+        sltiu   a3, a2, 8
+        li     t3, 1
+        bnez    a3, .L_copy_by_byte
+
+        andi    a3, a0, 7
+        li     t5, 8
+	/* Test if dest is not 8 bytes aligned.  */
+        bnez    a3, .L_dest_not_aligned
+.L_dest_aligned:
+        /* If dest is aligned, then copy.  */
+        srli    t4, a2, 6
+        /* Test if len less than 32 bytes.  */
+        beqz     t4, .L_len_less_16bytes
+	andi    a2, a2, 63
+
+.L_len_larger_16bytes:
+#if defined(__riscv_xtheadc)
+	ldd	a4, a5, 0(a1)
+	sdd	a4, a5, 0(a0)
+	ldd	a6, a7, 16(a1)
+	sdd	a6, a7, 16(a0)
+	ldd	a4, a5, 32(a1)
+	sdd	a4, a5, 32(a0)
+	ldd	a6, a7, 48(a1)
+	sub	t4, t4, t3
+        addi    a1, a1, 64
+	sdd	a6, a7, 48(a0)
+#else
+        ld      a4, 0(a1)
+        sd      a4, 0(a0)
+        ld      a5, 8(a1)
+        sd      a5, 8(a0)
+        ld      a6, 16(a1)
+        sd      a6, 16(a0)
+        ld      a7, 24(a1)
+        sd      a7, 24(a0)
+        ld      a4, 32(a1)
+        sd      a4, 32(a0)
+        ld      a5, 40(a1)
+        sd      a5, 40(a0)
+        ld      a6, 48(a1)
+        sd      a6, 48(a0)
+        ld      a7, 56(a1)
+        sub     t4, t4, t3
+        addi    a1, a1, 64
+        sd      a7, 56(a0)
+#endif
+        addi    a0, a0, 64
+	bnez	t4, .L_len_larger_16bytes
+
+.L_len_less_16bytes:
+	srli    t4, a2, 2
+        beqz     t4, .L_copy_by_byte
+        andi    a2, a2, 3
+.L_len_less_16bytes_loop:
+        lw      a4, 0(a1)
+	sub	t4, t4, t3
+        addi    a1, a1, 4
+        sw      a4, 0(a0)
+        addi    a0, a0, 4
+	bnez    t4, .L_len_less_16bytes_loop
+
+        /* Copy tail.  */
+.L_copy_by_byte:
+        andi    t4, a2, 7
+        beqz     t4, .L_return
+.L_copy_by_byte_loop:
+        lb     a4, 0(a1)
+	sub	t4, t4, t3
+        addi    a1, a1, 1
+        sb     a4, 0(a0)
+        addi    a0, a0, 1
+	bnez	t4, .L_copy_by_byte_loop
+
+.L_return:
+        mv      a0, t6
+        ret
+
+        /* If dest is not aligned, just copying some bytes makes the dest
+           align.  */
+.L_dest_not_aligned:
+        sub     a3, t5, a3
+        mv      t5, a3
+.L_dest_not_aligned_loop:
+        /* Makes the dest align.  */
+        lb     a4, 0(a1)
+	sub	a3, a3, t3
+        addi    a1, a1, 1
+        sb     a4, 0(a0)
+        addi    a0, a0, 1
+	bnez	a3, .L_dest_not_aligned_loop
+        sub     a2, a2, t5
+	sltiu	a3, a2, 4
+        bnez    a3, .L_copy_by_byte
+        /* Check whether the src is aligned.  */
+        j		.L_dest_aligned
+#endif
+END (memcpy)
+
+libc_hidden_builtin_def (memcpy)
+.weak memcpy

--- a/sysdeps/riscv/rv64/memmove.S
+++ b/sysdeps/riscv/rv64/memmove.S
@@ -1,0 +1,166 @@
+/* The assembly function for memcpy.  RISC-V version.
+   Copyright (C) 2018 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <sysdep.h>
+
+#  define LABLE_ALIGN   \
+        .balignl 16, 0x00000013
+
+#if defined(__riscv_v) && (__riscv_v >= 1000000)
+# define VLDB vle8.v
+# define VSTB vse8.v
+#else
+# define VLDB vlb.v
+# define VSTB vsb.v
+#endif
+
+ENTRY (memmove)
+#if defined(__riscv_vector)
+	sub	a3, a0, a1
+	bgeu	a3, a2, memcpy
+	add	a3, a0, a2
+	add	a1, a1, a2
+	sltiu	a4, a2, 16
+	bnez	a4, .loop_move
+	andi	a5, a0, 15
+	beqz	a5, .loop_move
+	vsetvli	t0, a5, e8, m4
+	sub	a1, a1, t0
+	VLDB	v0, (a1)
+	sub	a3, a3, t0
+	sub	a2, a2, t0
+	VSTB	v0, (a3)
+.loop_move:
+	vsetvli t0, a2, e8, m4
+	sub	a1, a1, t0
+	VLDB	v0, (a1)
+	sub	a3, a3, t0
+	sub	a2, a2, t0
+	VSTB	v0, (a3)
+	bnez	a2, .loop_move
+	ret
+#else
+	sub		a3, a0, a1
+	bgeu		a3, a2, memcpy
+
+	mv		t6, a0
+	add		a0, a0, a2
+	add		a1, a1, a2
+
+	/* Test if len less than 8 bytes.  */
+	sltiu	a3, a2, 8
+	li     t3, 1
+	li     t2, 4
+	bnez	a3, .L_copy_by_byte_m
+
+	andi	t5, a0, 7
+	/* Test if dest is not 8 bytes aligned.  */
+	bnez	t5, .L_dest_not_aligned_m
+.L_dest_aligned_m:
+	/* If dest is aligned, then copy.  */
+	srli	t4, a2, 6
+	/* Test if len less than 16 bytes.  */
+	beqz	t4, .L_len_less_16bytes_m
+	andi	a2, a2, 63
+	li     t1, 64
+
+	/* len > 16 bytes */
+	LABLE_ALIGN
+.L_len_larger_16bytes_m:
+	sub	a1, a1, t1
+	sub	a0, a0, t1
+#if defined(__riscv_xtheadc)
+	ldd	a6, a7, 48(a1)
+	sub	t4, t4, t3
+	sdd	a6, a7, 48(a0)
+	ldd	a4, a5, 32(a1)
+	sdd	a4, a5, 32(a0)
+	ldd	a6, a7, 16(a1)
+	sdd	a6, a7, 16(a0)
+	ldd	a4, a5, 0(a1)
+	sdd	a4, a5, 0(a0)
+#else
+        ld      a7, 56(a1)
+        sd      a7, 56(a0)
+        ld      a6, 48(a1)
+        sd      a6, 48(a0)
+        ld      a5, 40(a1)
+        sd      a5, 40(a0)
+        ld      a4, 32(a1)
+        sd      a4, 32(a0)
+	ld      a7, 24(a1)
+	sd      a7, 24(a0)
+	ld      a6, 16(a1)
+	sd      a6, 16(a0)
+	ld      a5, 8(a1)
+	sd      a5, 8(a0)
+	ld      a3, 0(a1)
+	sd      a3, 0(a0)
+        sub     t4, t4, t3
+#endif
+	bnez	t4,.L_len_larger_16bytes_m
+
+.L_len_less_16bytes_m:
+	srli    t4, a2, 2
+	beqz	t4, .L_copy_by_byte_m
+	andi    a2, a2, 3
+.L_len_less_16bytes_loop_m:
+	sub	a1, a1, t2
+	sub	a0, a0, t2
+	lw	a3, 0(a1)
+	sub     t4, t4, t3
+	sw	a3, 0(a0)
+	bnez    t4, .L_len_less_16bytes_loop_m
+
+	/* Copy tail.  */
+.L_copy_by_byte_m:
+	andi    t4, a2, 7
+	beqz	t4, .L_return_m
+.L_copy_by_byte_loop_m:
+	sub	a1, a1, t3
+	sub	a0, a0, t3
+	lb	a3, 0(a1)
+	sub     t4, t4, t3
+	sb	a3, 0(a0)
+	bnez    t4, .L_copy_by_byte_loop_m
+
+.L_return_m:
+	mv	a0, t6
+	ret
+
+	/* If dest is not aligned, just copying some bytes makes the dest
+	   align.  */
+.L_dest_not_aligned_m:
+	sub	a2, a2, t5
+.L_dest_not_aligned_loop_m:
+	sub	a1, a1, t3
+	sub	a0, a0, t3
+	/* Makes the dest align.  */
+	lb	a3, 0(a1)
+	sub     t5, t5, t3
+	sb	a3, 0(a0)
+	bnez	t5, .L_dest_not_aligned_loop_m
+	sltiu   a3, a2, 4
+	bnez    a3, .L_copy_by_byte_m
+	/* Check whether the src is aligned.  */
+	j	.L_dest_aligned_m
+#endif
+END (memmove)
+
+libc_hidden_builtin_def (memmove)
+.weak memmove

--- a/sysdeps/riscv/strcmp.S
+++ b/sysdeps/riscv/strcmp.S
@@ -1,0 +1,197 @@
+/* Optimized string compare implementation for RISC-V.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <sysdep.h>
+#include <sys/asm.h>
+
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+# error
+#endif
+
+ENTRY(strcmp)
+  or    a4, a0, a1
+#if defined(__riscv_xtheadc)
+#else
+  li    t2, -1
+#endif
+  and   a4, a4, SZREG-1
+  bnez  a4, .Lmisaligned
+
+#if SZREG == 4
+  li t3, 0x7f7f7f7f
+#else
+#ifndef __riscv_xtheadc
+  ld t3, mask
+#endif
+#endif
+
+  .macro check_one_word i n
+    REG_L a2, \i*SZREG(a0)
+    REG_L a3, \i*SZREG(a1)
+
+#if defined(__riscv_xtheadc)
+    tstnbz t0, a2
+    xor   t1, a2, a3
+    or    t2, t0, t1
+#else
+    and   t0, a2, t3
+    or    t1, a2, t3
+    add   t0, t0, t3
+    or    t0, t0, t1
+    bne   t0, t2, .Lnull\i
+#endif
+
+    .if \i+1-\n
+#if defined(__riscv_xtheadc)
+      bnez  t2, .Lmismatch
+#else
+      bne   a2, a3, .Lmismatch
+#endif
+    .else
+#if defined(__riscv_xtheadc)
+      bnez  t2, .Lmismatch
+      add   a0, a0, \n*SZREG
+      add   a1, a1, \n*SZREG
+      j     .Lloop
+#else
+      add   a0, a0, \n*SZREG
+      add   a1, a1, \n*SZREG
+      beq   a2, a3, .Lloop
+#endif
+      # fall through to .Lmismatch
+    .endif
+  .endm
+
+  .macro foundnull i n
+    .ifne \i
+      .Lnull\i:
+      add   a0, a0, \i*SZREG
+      add   a1, a1, \i*SZREG
+      .ifeq \i-1
+        .Lnull0:
+      .endif
+      bne   a2, a3, .Lmisaligned
+      li    a0, 0
+      ret
+    .endif
+  .endm
+
+.Lloop:
+  # examine full words at a time, favoring strings of a couple dozen chars
+#if __riscv_xlen == 32
+  check_one_word 0 5
+  check_one_word 1 5
+  check_one_word 2 5
+  check_one_word 3 5
+  check_one_word 4 5
+#else
+  check_one_word 0 3
+  check_one_word 1 3
+  check_one_word 2 3
+#endif
+  # backwards branch to .Lloop contained above
+
+.Lmismatch:
+#if defined(__riscv_xtheadc)
+  rev    t1, t2
+  ff1    t0, t1
+  andi   t0, t0, 0xf8
+  srl t1, a2, t0
+  andi t1, t1, 0xff
+  srl t2, a3, t0
+  andi t2, t2, 0xff
+  sub  a0, t1, t2
+  ret
+#else
+  # words don't match, but a2 has no null byte.
+#if __riscv_xlen == 64
+  sll   a4, a2, 48
+  sll   a5, a3, 48
+  bne   a4, a5, .Lmismatch_upper
+  sll   a4, a2, 32
+  sll   a5, a3, 32
+  bne   a4, a5, .Lmismatch_upper
+#endif
+  sll   a4, a2, 16
+  sll   a5, a3, 16
+  bne   a4, a5, .Lmismatch_upper
+
+  srl   a4, a2, 8*SZREG-16
+  srl   a5, a3, 8*SZREG-16
+  sub   a0, a4, a5
+  and   a1, a0, 0xff
+  bnez  a1, 1f
+  ret
+
+.Lmismatch_upper:
+  srl   a4, a4, 8*SZREG-16
+  srl   a5, a5, 8*SZREG-16
+  sub   a0, a4, a5
+  and   a1, a0, 0xff
+  bnez  a1, 1f
+  ret
+
+1:and   a4, a4, 0xff
+  and   a5, a5, 0xff
+  sub   a0, a4, a5
+  ret
+#endif
+
+.Lmisaligned:
+  # misaligned
+  lbu   a2, 0(a0)
+  lbu   a3, 0(a1)
+  add   a0, a0, 1
+  add   a1, a1, 1
+  bne   a2, a3, 1f
+  bnez  a2, .Lmisaligned
+
+1:
+  sub   a0, a2, a3
+  ret
+
+  # cases in which a null byte was detected
+#if __riscv_xlen == 32
+  foundnull 0 5
+  foundnull 1 5
+  foundnull 2 5
+  foundnull 3 5
+  foundnull 4 5
+#else
+#ifndef __riscv_xtheadc
+  foundnull 0 3
+  foundnull 1 3
+  foundnull 2 3
+#endif
+#endif
+
+END(strcmp)
+
+weak_alias(strcmp, __GI_strcmp)
+
+#if SZREG == 8
+#ifndef __riscv_xtheadc
+#ifdef __PIC__
+.section .rodata.cst8,"aM",@progbits,8
+#else
+.section .srodata.cst8,"aM",@progbits,8
+#endif
+.align 3
+mask: .8byte 0x7f7f7f7f7f7f7f7f
+#endif
+#endif

--- a/sysdeps/unix/sysv/linux/riscv/ldconfig.h
+++ b/sysdeps/unix/sysv/linux/riscv/ldconfig.h
@@ -22,13 +22,31 @@
 #define LD_SO_SUFFIX ".so.1"
 
 #if __riscv_xlen == 64
+#if defined(__riscv_xthead) && defined(__riscv_v)
+#if __riscv_v >= 1000000
+# define LD_SO_ABI "riscv64v_xthead-lp64"
+#else
+# define LD_SO_ABI "riscv64v0p7_xthead-lp64"
+#endif
+#elif defined(__riscv_xthead)
+# define LD_SO_ABI "riscv64xthead-lp64"
+#else
 # define LD_SO_ABI "riscv64-lp64"
+#endif
+#else
+#if defined(__riscv_xthead) && defined(__riscv_v)
+# define LD_SO_ABI "riscv32v_xthead-ilp32"
+#elif defined(__riscv_xthead)
+# define LD_SO_ABI "riscv32xthead-ilp32"
 #else
 # define LD_SO_ABI "riscv32-ilp32"
 #endif
+#endif
 
 #define SYSDEP_KNOWN_INTERPRETER_NAMES				\
+  { LD_SO_PREFIX LD_SO_ABI "v" LD_SO_SUFFIX, FLAG_ELF_LIBC6 },  \
   { LD_SO_PREFIX LD_SO_ABI "d" LD_SO_SUFFIX, FLAG_ELF_LIBC6 },	\
+  { LD_SO_PREFIX LD_SO_ABI "dv" LD_SO_SUFFIX, FLAG_ELF_LIBC6 }, \
   { LD_SO_PREFIX LD_SO_ABI     LD_SO_SUFFIX, FLAG_ELF_LIBC6 },
 
 #define SYSDEP_KNOWN_LIBRARY_NAMES	\

--- a/sysdeps/unix/sysv/linux/riscv/shlib-versions
+++ b/sysdeps/unix/sysv/linux/riscv/shlib-versions
@@ -1,4 +1,51 @@
-%if RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64
+%if RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 1 && RISCV_ARCH_V >= 1000000
+ld=ld-linux-riscv64v_xthead-lp64dv.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 1 && RISCV_ARCH_V != 0
+ld=ld-linux-riscv64v0p7_xthead-lp64dv.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 0 && RISCV_ABI_VECTOR == 1 && RISCV_ARCH_V >= 1000000
+ld=ld-linux-riscv64v-lp64dv.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 0 && RISCV_ABI_VECTOR == 1 && RISCV_ARCH_V != 0
+ld=ld-linux-riscv64v0p7-lp64dv.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 0 && RISCV_ARCH_V >= 1000000
+ld=ld-linux-riscv64v_xthead-lp64d.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 0 && RISCV_ARCH_V != 0
+ld=ld-linux-riscv64v0p7_xthead-lp64d.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 0 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 1 && RISCV_ARCH_V >= 1000000
+ld=ld-linux-riscv64v_xthead-lp64v.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 0 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 1 && RISCV_ARCH_V != 0
+ld=ld-linux-riscv64v0p7_xthead-lp64v.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 0 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 0 && RISCV_ARCH_V >= 1000000
+ld=ld-linux-riscv64v_xthead-lp64.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 0 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 0 && RISCV_ARCH_V != 0
+ld=ld-linux-riscv64v0p7_xthead-lp64.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 1
+ld=ld-linux-riscv64xthead-lp64d.so.1
+DEFAULT         GLIBC_2.27
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 0 && RISCV_ARCH_XTHEAD == 1
+ld=ld-linux-riscv64xthead-lp64.so.1
+DEFAULT         GLIBC_2.27
+
+%elif RISCV_ABI_XLEN == 32 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 0 && RISCV_ARCH_V >= 1000000
+ld=ld-linux-riscv32v_xthead-ilp32d.so.1
+DEFAULT         GLIBC_2.32
+%elif RISCV_ABI_XLEN == 32 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 1
+ld=ld-linux-riscv32xthead-ilp32d.so.1
+DEFAULT         GLIBC_2.32
+%elif RISCV_ABI_XLEN == 32 && RISCV_ABI_FLEN == 0 && RISCV_ARCH_XTHEAD == 1
+ld=ld-linux-riscv32xthead-ilp32.so.1
+DEFAULT         GLIBC_2.32
+
+%elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64
 DEFAULT		GLIBC_2.27
 ld=ld-linux-riscv64-lp64d.so.1
 %elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 0

--- a/sysdeps/unix/sysv/linux/riscv/shlib-versions
+++ b/sysdeps/unix/sysv/linux/riscv/shlib-versions
@@ -37,13 +37,13 @@ DEFAULT         GLIBC_2.27
 
 %elif RISCV_ABI_XLEN == 32 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 1 && RISCV_ABI_VECTOR == 0 && RISCV_ARCH_V >= 1000000
 ld=ld-linux-riscv32v_xthead-ilp32d.so.1
-DEFAULT         GLIBC_2.32
+DEFAULT         GLIBC_2.33
 %elif RISCV_ABI_XLEN == 32 && RISCV_ABI_FLEN == 64 && RISCV_ARCH_XTHEAD == 1
 ld=ld-linux-riscv32xthead-ilp32d.so.1
-DEFAULT         GLIBC_2.32
+DEFAULT         GLIBC_2.33
 %elif RISCV_ABI_XLEN == 32 && RISCV_ABI_FLEN == 0 && RISCV_ARCH_XTHEAD == 1
 ld=ld-linux-riscv32xthead-ilp32.so.1
-DEFAULT         GLIBC_2.32
+DEFAULT         GLIBC_2.33
 
 %elif RISCV_ABI_XLEN == 64 && RISCV_ABI_FLEN == 64
 DEFAULT		GLIBC_2.27


### PR DESCRIPTION
Rebase T-head glibc 2.36:

Fix conflicts in commits, depart memcpy/move assembler file define.